### PR TITLE
Adds semicolon to end of __reach_config variable

### DIFF
--- a/simplereach.module
+++ b/simplereach.module
@@ -172,7 +172,7 @@ function simplereach_preprocess_page(&$variables) {
        );
        if(!empty($domain)) $configjs['domain'] = $domain;
 
-       $script = "__reach_config = " . str_replace('\/', '/', json_encode($configjs));
+       $script = "__reach_config = " . str_replace('\/', '/', json_encode($configjs)) . ";";
        $script .= "
         (function(){
           var s = document.createElement('script');


### PR DESCRIPTION
I was not seeing any request to "http://cc.simplereach.com/n?pid=..." fire without a semicolon at the end of this javascript statement.
